### PR TITLE
fix protobuf bin include path

### DIFF
--- a/codegen/server_template.cpp
+++ b/codegen/server_template.cpp
@@ -216,7 +216,7 @@ $ToolMainFile$: $ToolFile$.o $ToolImplFile$.o $ToolMainFile$.o
 $MessageFile$.cc: $MessageFile$.h
 
 $MessageFile$.h: $ProtoFile$
-	$(PROTOBUF_ROOT)/src/protoc -I$(PROTOBUF_ROOT)/src --cpp_out=. -I$(PHXRPC_ROOT) -I. $^
+	$(PROTOBUF_ROOT)/bin/protoc -I$(PROTOBUF_ROOT)/include --cpp_out=. -I$(PHXRPC_ROOT) -I. $^
 
 ########## client ##########
 

--- a/phxrpc/Makefile
+++ b/phxrpc/Makefile
@@ -27,7 +27,7 @@ libphxrpc.a: $(LIB_OBJS)
 rpc/phxrpc.pb.cc: rpc/phxrpc.pb.h
 
 rpc/phxrpc.pb.h: rpc/phxrpc.proto
-	cd ..; $(PROTOBUF_ROOT)/src/protoc -I$(PROTOBUF_ROOT)/src -I. --cpp_out=. phxrpc/$<;
+	cd ..; $(PROTOBUF_ROOT)/bin/protoc -I$(PROTOBUF_ROOT)/include -I. --cpp_out=. phxrpc/$<;
 
 clean:
 	@( $(RM) $(TARGETS) $(TEST_TARGETS) )


### PR DESCRIPTION
protobuf集成的方式有两种：

(1) protobuf的源代码编译后不安装，将源代码的路径链接到third_party:
```bash
user@gentoo third_party % pwd
/home/user/dist/phxrpc/third_party
user@gentoo third_party % rmdir protobuf 
user@gentoo third_party % ln -s /home/user/Dropbox/ReadTheCode/protobuf .
```
这个时候需要的资源：
a.头文件目录: third_party/protobuf/src/
b.protoc: third_party/protobuf/src/protoc
c.库文件: third_party/protobuf/src/.libs/libprotobuf.a
此时需要修改config.mk

```bash
diff --git a/phxrpc.mk b/phxrpc.mk
index d2486dd..70670c0 100644
--- a/phxrpc.mk
+++ b/phxrpc.mk
@@ -33,9 +33,10 @@ RM = /bin/rm -f
 
 CFLAGS = -std=c++11 -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC -m64 $(OPT) \
                 -I$(PROTOBUF_ROOT)/include \
+               -I$(PROTOBUF_ROOT)/src\
                 -I$(PHXRPC_ROOT) \
 
-LDFLAGS = -L$(PROTOBUF_ROOT)/lib/ $(PROTOBUF_ROOT)/lib/libprotobuf.a \
+LDFLAGS = -L$(PROTOBUF_ROOT)/src/.libs/ $(PROTOBUF_ROOT)/src/.libs/libprotobuf.a \
                  -lstdc++ -lpthread -lm
```
但是最后在sample的时候还是core.dump了。

(2) 在编译安装protobuf的时候，指定--prefix到protobuf，然后安装：
```bash
user@gentoo protobuf % ./autogen.sh
user@gentoo protobuf % ./configure --prefix=/home/user/dist/phxrpc/third_party/protobuf/
user@gentoo protobuf % make 
user@gentoo protobuf % make install
user@gentoo phxrpc % ls third_party/protobuf/
bin  include  lib
```
但是发现现存代码中还有硬编码到src的，需要修改
```bash
diff --git a/codegen/server_template.cpp b/codegen/server_template.cpp
index af9f1aa..063c9ad 100644
--- a/codegen/server_template.cpp
+++ b/codegen/server_template.cpp
@@ -216,7 +216,7 @@ $ToolMainFile$: $ToolFile$.o $ToolImplFile$.o $ToolMainFile$.o
 $MessageFile$.cc: $MessageFile$.h
 
 $MessageFile$.h: $ProtoFile$
-       $(PROTOBUF_ROOT)/src/protoc -I$(PROTOBUF_ROOT)/src --cpp_out=. -I$(PHXRPC_ROOT) -I. $^
+       $(PROTOBUF_ROOT)/bin/protoc -I$(PROTOBUF_ROOT)/include --cpp_out=. -I$(PHXRPC_ROOT) -I. $^
 
 ########## client ##########
 
diff --git a/phxrpc/Makefile b/phxrpc/Makefile
index e8e9aa5..46c933d 100644
--- a/phxrpc/Makefile
+++ b/phxrpc/Makefile
@@ -27,7 +27,7 @@ libphxrpc.a: $(LIB_OBJS)
 rpc/phxrpc.pb.cc: rpc/phxrpc.pb.h
 
 rpc/phxrpc.pb.h: rpc/phxrpc.proto
-       cd ..; $(PROTOBUF_ROOT)/src/protoc -I$(PROTOBUF_ROOT)/src -I. --cpp_out=. phxrpc/$<;
+       cd ..; $(PROTOBUF_ROOT)/bin/protoc -I$(PROTOBUF_ROOT)/include -I. --cpp_out=. phxrpc/$<;
```

不知道是什么原因，感觉提交的代码是上面两种的混合，可能是多人开发维护的环境不一致吧。不过作为一般用户，还是建议第二种方式。